### PR TITLE
fix django autoreload by making sure that the correct system code is returned

### DIFF
--- a/clr/main.py
+++ b/clr/main.py
@@ -10,12 +10,15 @@ from clr.commands import resolve_command, get_namespace
 
 DEBUG_MODE = os.environ.get("CLR_DEBUG", "").lower() in ("true", "1")
 
+
 def on_exit(signum, frame):
     beeline.add_trace_field("killed_by_signal", signal.Signals(signum).name)
     beeline.close()
 
+
 signal.signal(signal.SIGINT, on_exit)
 signal.signal(signal.SIGTERM, on_exit)
+
 
 @contextmanager
 def init_beeline(namespace_key, cmd_name):
@@ -81,6 +84,8 @@ def main(argv=None):
                 )
                 if isinstance(result, (int, bool)):
                     exit_code = int(result)
+            except SystemExit as err:
+                exit_code = err.code
             except:
                 print(traceback.format_exc(), file=sys.stderr)
                 beeline.add_trace_field("raised_exception", True)


### PR DESCRIPTION
Auto-reload requires the child process to return a sys.exit(3)

Clr main was catching this exception which resulted in an incorrect exit code 231 as seen by this trace which gets thrown after a file has been changed.

BEFORE:
```
[2021-10-26T04:53:32Z django.utils.autoreload] INFO: 231 exit_code.
[2021-10-26T04:53:32Z django.utils.autoreload] INFO: 231 exit_code.
Traceback (most recent call last):
  File "/Users/gary.tsang/workspace/color/local/virtualenv3/lib/python3.6/site-packages/clr/main.py", line 80, in main
    *bound_args.args, **bound_args.kwargs
...
    addrport=port or self._get_project_port_if_exists(project) or '8000',
  File "/Users/gary.tsang/workspace/color/local/virtualenv3/lib/python3.6/site-packages/django/core/management/__init__.py", line 148, in call_command
    return command.execute(*args, **defaults)
  File "/Users/gary.tsang/workspace/color/local/virtualenv3/lib/python3.6/site-packages/django/core/management/commands/runserver.py", line 60, in execute
    super().execute(*args, **options)
  File "/Users/gary.tsang/workspace/color/local/virtualenv3/lib/python3.6/site-packages/django/core/management/base.py", line 364, in execute
    output = self.handle(*args, **options)
  File "/Users/gary.tsang/workspace/color/local/virtualenv3/lib/python3.6/site-packages/django/core/management/commands/runserver.py", line 95, in handle
    self.run(**options)
  File "/Users/gary.tsang/workspace/color/local/virtualenv3/lib/python3.6/site-packages/django/core/management/commands/runserver.py", line 102, in run
    autoreload.run_with_reloader(self.inner_run, **options)
  File "/Users/gary.tsang/workspace/color/local/virtualenv3/lib/python3.6/site-packages/django/utils/autoreload.py", line 639, in run_with_reloader
    sys.exit(exit_code)
SystemExit: 231
```

AFTER:

```
[2021-10-26T17:48:10Z django.utils.autoreload] INFO: ...
[2021-10-26T17:48:11Z django.utils.autoreload] INFO: 3 exit_code.
[2021-10-26T17:48:11Z django.utils.autoreload] INFO: 3 exit_code.
[2021-10-26T17:48:13Z ddtrace.monkey] INFO: patched 1/1 modules (celery)
[2021-10-26T17:48:15Z py.warnings] WARNING: /Users/gary.tsang/workspace/color/local/virtualenv3/lib/python3.6/site-packages/sklearn/ensemble/weight_boosting.py:29: DeprecationWarning: numpy.core.umath_tests is an internal NumPy module and should not be imported. It will be removed in a future NumPy release.
  from numpy.core.umath_tests import inner1d

[2021-10-26T17:48:17Z django.utils.autoreload] INFO: Watching for file changes with WatchmanReloader
[2021-10-26T17:48:17Z django.utils.autoreload] INFO: Watching for file changes with WatchmanReloader
Performing system checks...
System check identified no issues (0 silenced).
October 26, 2021 - 10:48:20
...
Starting development server at http://127.0.0.1:8000/
Quit the server with CONTROL-C.
```
